### PR TITLE
Fixed link to ServerPilot (Justin Samuel's company).

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
 
 						<p>RequestPolicy is <a href="https://www.gnu.org/philosophy/free-sw.html">free software</a>, licensed under the <a href="http://www.gnu.org/copyleft/gpl.html">GPL v3.</a></p>
 
-						<p>RequestPolicy was originally developped by <a href="https://github.com/jsamuel">Justin Samuel</a>. Please support the developper by telling PHP developers and hosting companies about his company, <a href="https://www.serverpilot.com/">ServerPilot</a>, a secure control panel for PHP developers, and follow <a href="https://twitter.com/serverpilot">@ServerPilot</a> on Twitter!</p>
+						<p>RequestPolicy was originally developped by <a href="https://github.com/jsamuel">Justin Samuel</a>. Please support the developper by telling PHP developers and hosting companies about his company, <a href="https://www.serverpilot.io/">ServerPilot</a>, a secure control panel for PHP developers, and follow <a href="https://twitter.com/serverpilot">@ServerPilot</a> on Twitter!</p>
 
 						<p>Some people Justin would especially like to thank (but are not limited to):</p>
 


### PR DESCRIPTION
The link to ServerPilot (Justin Samuel's company) in the About (attribution) section of requestpolicycontinued.github.io points to https://serverpilot.com/. This is incorrect, it should be https://serverpilot.io/.

Sources: (these all have links to https://serverpilot.io/ NOT https://serverpilot.com/)
- https://www.requestpolicy.com/ (original RequestPolicy website)
- https://twitter.com/serverpilot (ServerPilot project twitter)
- https://www.digitalocean.com/community/projects/serverpilot (DigitalOcean featured community project)

This pull request changes it to the correct link. It would be unfortunate to misquote the original author's company.
